### PR TITLE
Bugfix: ROS high memory usage

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,10 @@ services:
   simulator:
     container_name: simulator
     privileged: true
+    ulimits:
+      nofile:
+        soft: 1024
+        hard: 524288
     build:
       context: .
       dockerfile: ./simulator/Dockerfile


### PR DESCRIPTION
Issue is described on stackexchange:
https://robotics.stackexchange.com/questions/93752/rosout-high-memory-usage

Without limiting the nofile soft/hard limit, ROS nodes will consume abnormal amount of memory.
On a system with `ulimit -Hn` of `1073741816`, that's 4 GB per node.

By limiting the max number of opened file descriptors to 1024:524288, ROS nodes will consume 2 MB instead.