### PR TITLE
Fixed logic bug when detecting GPU Runtime in ./start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -80,10 +80,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- Helpers ---
+# Returns 1 if GPU is Ok, returns 0 if GPU fails
 gpu_ok() {
-  command -v nvidia-smi >/dev/null 2>&1 || return 1
-  docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q '"nvidia"' || return 1
-  return 0
+  command -v nvidia-smi >/dev/null 2>&1 || return 0
+  docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q '"nvidia"' || return 0
+  return 1
 }
 
 check_virtual_interface() {
@@ -168,6 +169,7 @@ if [[ -z "${sim_mode}" ]]; then
 fi
 
 # FULL mode GPU check
+
 if [[ "${sim_mode}" == "full" ]] && ! gpu_ok; then
   echo "GPU runtime not detected (need NVIDIA drivers + nvidia-container-runtime)."
   read -rp "Fall back to Lite mode? [Y/n]: " fb


### PR DESCRIPTION
This pull request fixes a very small bug in `start.sh`  when detecting whether or not the system has a NVIDIA GPU Driver. 

More specifically, before the pull request, `gpu_ok` returns 1 upon failure, which sets `! gpu_ok` to 0, which means the full mode GPU warning in line 173 never runs when the GPU check fails (and vice versa). This pull request fixes the small logic error.

```bash
gpu_ok() {
# Returns 1 if GPU is Ok, returns 0 if GPU fails
  command -v nvidia-smi >/dev/null 2>&1 || return 0   # Used to be 1
  docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q '"nvidia"' || return 0
  return 1    # Used to be 0
}
```

Now, in line 173, the statement will execute if the GPU is **not detected**.

```bash
if [[ "${sim_mode}" == "full" ]] && ! gpu_ok; then
```