### PR TITLE
Fix start.sh --wifi failures

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -230,23 +230,9 @@ if [[ "$wifi_simulation" == "y" ]]; then
   {
     echo -e "${CYAN}[+] Starting Docker Lab Environment - $(date)${NC}"
 
-    echo -e "${CYAN}[+] Loading kernel modules...${NC}"
-    modprobe mac80211_hwsim radios=4
-
-    first_virtual_card_name="$(first_virtual_card || true)"
-    echo "First virtual card: ${first_virtual_card_name:-<none>}"
-    if [[ -z "$first_virtual_card_name" ]]; then
-      echo "Error: No virtual card found. Is 'mac80211_hwsim' available?"
-      exit 1
-    fi
-
-    # Put first card in monitor mode & kill interfering PIDs
-    output="$(airmon-ng start "$first_virtual_card_name" 2>&1 || true)"
-    while read -r pid; do
-      echo "Killing process $pid"; kill "$pid" || true
-    done < <(echo "$output" | grep -oP '^\s*\K[0-9]+(?=\s+\S)')
-
-    # Start stack
+    # Build/pull Docker images BEFORE touching the host wireless stack.
+    # airmon-ng below kills NetworkManager/wpa_supplicant/dhclient, which
+    # breaks DNS and any in-flight image pulls.
     stop_all_stacks
     echo -e "${CYAN}[+] Starting Docker Compose (mode: ${sim_mode})...${NC}"
     compose up -d --build
@@ -269,6 +255,22 @@ if [[ "$wifi_simulation" == "y" ]]; then
       ((RETRY_COUNT++)); sleep "$RETRY_INTERVAL"
     done
     [[ $RETRY_COUNT -eq $MAX_RETRIES ]] && { echo -e "${RED}Containers not ready in time.${NC}"; exit 1; }
+
+    echo -e "${CYAN}[+] Loading kernel modules...${NC}"
+    modprobe mac80211_hwsim radios=4
+
+    first_virtual_card_name="$(first_virtual_card || true)"
+    echo "First virtual card: ${first_virtual_card_name:-<none>}"
+    if [[ -z "$first_virtual_card_name" ]]; then
+      echo "Error: No virtual card found. Is 'mac80211_hwsim' available?"
+      exit 1
+    fi
+
+    # Put first card in monitor mode & kill interfering PIDs
+    output="$(airmon-ng start "$first_virtual_card_name" 2>&1 || true)"
+    while read -r pid; do
+      echo "Killing process $pid"; kill "$pid" || true
+    done < <(echo "$output" | grep -oP '^\s*\K[0-9]+(?=\s+\S)')
 
     DOCKER_BRIDGE_IP="$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+' || true)"
     echo -e "${CYAN}[+] Docker bridge IP: ${DOCKER_BRIDGE_IP:-unknown}${NC}"

--- a/start.sh
+++ b/start.sh
@@ -20,6 +20,10 @@ print_banner() {
   [[ -f "$SCRIPT_DIR/banner.txt" ]] && cat "$SCRIPT_DIR/banner.txt"
 }
 
+print_text_banner() {
+  [[ -f "$SCRIPT_DIR/banner.txt" ]] && tail -n 5 "$SCRIPT_DIR/banner.txt"
+}
+
 show_help() {
   print_banner
   cat <<EOF
@@ -324,6 +328,9 @@ if [[ "$wifi_simulation" == "y" ]]; then
       ip route replace default via 192.168.13.1 dev '$gcs_interface';
     " || true
 
+    echo -e "${CYAN}"
+    print_text_banner
+    echo -e "${NC}"
     echo -e "${CYAN}------------------------------------------------------"
     echo -e "${CYAN}[+] Build Complete."
     echo -e "${CYAN}[+] Version: ${version}"
@@ -349,6 +356,9 @@ elif [[ "$wifi_simulation" == "n" ]]; then
     echo -e "${CYAN}[+] Starting Docker Compose (mode: ${sim_mode})...${NC}"
     compose up -d --build
 
+    echo -e "${CYAN}"
+    print_text_banner
+    echo -e "${NC}"
     echo -e "${CYAN}------------------------------------------------------"
     echo -e "${CYAN}[+] Build Complete."
     echo -e "${CYAN}[+] Version: ${version}"

--- a/start.sh
+++ b/start.sh
@@ -325,7 +325,7 @@ if [[ "$wifi_simulation" == "y" ]]; then
       pkill -x wpa_supplicant 2>/dev/null || true;
       wpa_supplicant -B -i '$gcs_interface' -c /etc/wpa_supplicant/wpa_supplicant.conf -D nl80211 || true;
       ip addr replace 192.168.13.14/24 dev '$gcs_interface';
-      ip route replace default via 192.168.13.1 dev '$gcs_interface';
+      ip route replace 192.168.13.0/24 dev '$gcs_interface';
     " || true
 
     echo -e "${CYAN}"

--- a/start.sh
+++ b/start.sh
@@ -242,9 +242,6 @@ if [[ "$wifi_simulation" == "y" ]]; then
     GCS_CID="$(compose ps -q "$GCS_SVC" || true)"
     [[ -n "$CC_CID" && -n "$GCS_CID" ]] || { echo "Containers not up yet."; }
 
-    echo -e "${CYAN}[+] Fetching Docker Compose logs...${NC}"
-    compose logs -f "$SIM_SVC" "$CC_SVC" "$GCS_SVC" &
-
     # Readiness
     MAX_RETRIES=100; RETRY_INTERVAL=10; RETRY_COUNT=0
     while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
@@ -338,6 +335,9 @@ if [[ "$wifi_simulation" == "y" ]]; then
     echo -e "${CYAN}[+] Log file: dvd.log"
     echo -e "${CYAN}[+] Simulator: http://localhost:8000"
     echo -e "${CYAN}------------------------------------------------------${NC}"
+
+    echo -e "${CYAN}[+] Fetching Docker Compose logs...${NC}"
+    compose logs -f "$SIM_SVC" "$CC_SVC" "$GCS_SVC"
   } 2>&1 | tee -a "$LOG_FILE"
 
 elif [[ "$wifi_simulation" == "n" ]]; then
@@ -348,8 +348,6 @@ elif [[ "$wifi_simulation" == "n" ]]; then
     echo -e "${CYAN}[+] Starting Docker Compose (mode: ${sim_mode})...${NC}"
     compose up -d --build
 
-    compose logs -f "$SIM_SVC" "$CC_SVC" "$GCS_SVC" &
-
     echo -e "${CYAN}------------------------------------------------------"
     echo -e "${CYAN}[+] Build Complete."
     echo -e "${CYAN}[+] Version: ${version}"
@@ -358,7 +356,10 @@ elif [[ "$wifi_simulation" == "n" ]]; then
     echo -e "${CYAN}[+] Damn Vulnerable Drone Lab Environment is running..."
     echo -e "${CYAN}[+] Log file: dvd.log"
     echo -e "${CYAN}[+] Simulator: http://localhost:8000"
-    echo -e "${CYAN}------------------------------------------------------"
+    echo -e "${CYAN}------------------------------------------------------${NC}"
+
+    echo -e "${CYAN}[+] Fetching Docker Compose logs...${NC}"
+    compose logs -f "$SIM_SVC" "$CC_SVC" "$GCS_SVC"
   } 2>&1 | tee -a "$LOG_FILE"
 else
   echo "Invalid input for Wi-Fi selection."

--- a/start.sh
+++ b/start.sh
@@ -318,10 +318,11 @@ if [[ "$wifi_simulation" == "y" ]]; then
 
     echo -e "${CYAN}[+] Setting up Ground Control Station Wi-Fi client...${NC}"
     docker exec "$GCS_CID" sh -c "
-      wpa_supplicant -B -i '$gcs_interface' -c /etc/wpa_supplicant/wpa_supplicant.conf -D nl80211;
-      ip addr add 192.168.13.14/24 dev '$gcs_interface';
-      ip route add default via 192.168.13.1 dev '$gcs_interface';
-    "
+      pkill -x wpa_supplicant 2>/dev/null || true;
+      wpa_supplicant -B -i '$gcs_interface' -c /etc/wpa_supplicant/wpa_supplicant.conf -D nl80211 || true;
+      ip addr replace 192.168.13.14/24 dev '$gcs_interface';
+      ip route replace default via 192.168.13.1 dev '$gcs_interface';
+    " || true
 
     echo -e "${CYAN}------------------------------------------------------"
     echo -e "${CYAN}[+] Build Complete."

--- a/start.sh
+++ b/start.sh
@@ -278,6 +278,7 @@ if [[ "$wifi_simulation" == "y" ]]; then
     echo -e "${CYAN}[+] Moving interfaces to Docker containers...${NC}"
     companion_computer_interface="$(increment_interface_number "$first_virtual_card_name")"
     gcs_interface="$(increment_interface_number "$companion_computer_interface")"
+    kali_interface="$(increment_interface_number "$gcs_interface")"
 
     # Get PIDs using container IDs
     CC_PID="$(docker inspect --format '{{ .State.Pid }}' "$CC_CID")"
@@ -329,6 +330,9 @@ if [[ "$wifi_simulation" == "y" ]]; then
     echo -e "${CYAN}[+] Build Complete."
     echo -e "${CYAN}[+] Version: ${version}"
     echo -e "${CYAN}[+] Mode: ${sim_mode^^}"
+    echo -e "${CYAN}------------------------------------------------------"
+    echo -e "${CYAN}[+] - Virtual interface ${first_virtual_card_name}mon put into monitoring mode."
+    echo -e "${CYAN}[+] - Virtual interface ${kali_interface} is available for regular wifi networking."
     echo -e "${CYAN}------------------------------------------------------"
     echo -e "${CYAN}[+] Damn Vulnerable Drone Lab Environment is running..."
     echo -e "${CYAN}[+] Log file: dvd.log"


### PR DESCRIPTION
- Build/pull Docker images before airmon-ng kills NetworkManager (avoids DNS failure during image pull)
- Make GCS Wi-Fi setup idempotent so re-runs don't trip set -e
- Route only 192.168.13.0/24 over the simulated Wi-Fi link so QGC keeps real internet for terrain tile fetches
- Move build-complete banner to the very end of output so it isn't buried under streaming container logs